### PR TITLE
feat: Initial project structure and core files for Discord-like chat app

### DIFF
--- a/chat-app/src/client/main.odin
+++ b/chat-app/src/client/main.odin
@@ -1,0 +1,85 @@
+package client
+
+import rl "vendor:raylib" // Assuming raylib is in a vendor directory or system path
+
+// Forward declarations for procedures to be defined later
+init_app :: proc(app: ^App) ---
+update_app :: proc(app: ^App) ---
+draw_app :: proc(app: ^App) ---
+cleanup_app :: proc(app: ^App) ---
+
+// Forward declarations for types that might be in other files
+User :: struct {} // Placeholder
+Server :: struct {} // Placeholder
+Channel :: struct {} // Placeholder
+UIManager :: struct {} // Placeholder
+NetworkClient :: struct {} // Placeholder
+
+
+AppState :: enum {
+    LOGIN,
+    MAIN_CHAT,
+    SETTINGS,
+}
+
+App :: struct {
+    state:           AppState,
+    window_width:    i32,
+    window_height:   i32,
+    current_user:    ^User,          // Placeholder
+    current_server:  ^Server,        // Placeholder
+    current_channel: ^Channel,       // Placeholder
+    ui_manager:      ^UIManager,     // Placeholder
+    network_client:  ^NetworkClient, // Placeholder
+    image_cache:     map[string]rl.Texture2D,
+}
+
+main :: proc() {
+    app := App{
+        window_width = 1200,
+        window_height = 800,
+        state = .LOGIN,
+    }
+
+    rl.InitWindow(app.window_width, app.window_height, "Discord Clone")
+    rl.SetTargetFPS(60)
+
+    // init_app(&app) // Call to placeholder
+
+    for !rl.WindowShouldClose() {
+        // update_app(&app) // Call to placeholder
+
+        rl.BeginDrawing()
+        rl.ClearBackground(rl.RAYWHITE)
+        // draw_app(&app) // Call to placeholder
+        rl.DrawText("Basic Raylib Window!", 190, 200, 20, rl.LIGHTGRAY)
+        rl.EndDrawing()
+    }
+
+    // cleanup_app(&app) // Call to placeholder
+    rl.CloseWindow()
+}
+
+// Placeholder implementations (to be expanded in later steps)
+init_app :: proc(app: ^App) {
+    // Initialize application state, UI, network, etc.
+    // For now, this can be empty or have minimal setup.
+    app.image_cache = make(map[string]rl.Texture2D)
+}
+
+update_app :: proc(app: ^App) {
+    // Handle input, update game logic, network events, etc.
+}
+
+draw_app :: proc(app: ^App) {
+    // Draw all UI elements based on app.state
+}
+
+cleanup_app :: proc(app: ^App) {
+    // Free resources, close connections, etc.
+    // Example: cleanup image cache if it were populated
+    // for path, texture in app.image_cache {
+    //     rl.UnloadTexture(texture)
+    // }
+    // delete(app.image_cache)
+}

--- a/chat-app/src/server/websocket/server.odin
+++ b/chat-app/src/server/websocket/server.odin
@@ -1,0 +1,40 @@
+package websocket
+
+import "core:net"
+import "core:thread"
+import "core:sync" // Added for sync.Mutex
+import "core:fmt" // Added for fmt.println
+
+// Forward declarations for types that might be in other files or defined later
+User :: struct {}    // Placeholder from shared/types.odin (or define fully if not circular)
+Channel :: struct {} // Placeholder from shared/types.odin
+
+WebSocketServer :: struct {
+    port:        int,
+    clients:     map[u64]^Client,
+    channels:    map[u64]^Channel, // Assuming Channel is defined in shared/types.odin
+    mutex:       sync.Mutex,
+}
+
+Client :: struct {
+    id:         u64,
+    connection: net.TCP_Socket, // This will likely need to be a WebSocket connection object from a library
+    user:       ^User,          // Assuming User is defined in shared/types.odin
+    current_channel: u64,
+}
+
+start_server :: proc(server: ^WebSocketServer) {
+    // Initialize server
+    // Accept connections
+    // Handle message routing
+    // Placeholder implementation
+    fmt.println("WebSocket server starting...")
+}
+
+handle_client :: proc(client: ^Client) {
+    // Message parsing
+    // Command handling
+    // Broadcast logic
+    // Placeholder implementation
+    fmt.println("Handling client...")
+}

--- a/chat-app/src/shared/protocol/messages.odin
+++ b/chat-app/src/shared/protocol/messages.odin
@@ -1,0 +1,20 @@
+package protocol
+
+import "core:time"
+
+MessageType :: enum {
+    USER_JOIN,
+    USER_LEAVE,
+    CHAT_MESSAGE,
+    IMAGE_MESSAGE,
+    CHANNEL_JOIN,
+    CHANNEL_LEAVE,
+    USER_STATUS_UPDATE,
+}
+
+NetworkMessage :: struct {
+    type:      MessageType,
+    sender_id: u64,
+    data:      []u8,
+    timestamp: time.Time,
+}

--- a/chat-app/src/shared/types.odin
+++ b/chat-app/src/shared/types.odin
@@ -1,0 +1,42 @@
+package shared
+
+import "core:time"
+
+User :: struct {
+    id:       u64,
+    username: string,
+    email:    string,
+    status:   UserStatus,
+    avatar:   string,
+}
+
+UserStatus :: enum {
+    ONLINE,
+    AWAY,
+    BUSY,
+    OFFLINE,
+}
+
+Server :: struct {
+    id:       u64,
+    name:     string,
+    owner_id: u64,
+    channels: [dynamic]Channel,
+}
+
+Channel :: struct {
+    id:        u64,
+    name:      string,
+    server_id: u64,
+    messages:  [dynamic]Message,
+}
+
+Message :: struct {
+    id:         u64,
+    author_id:  u64,
+    channel_id: u64,
+    content:    string,
+    image_path: string,  // For image attachments
+    timestamp:  time.Time,
+    edited:     bool,
+}


### PR DESCRIPTION
Sets up the basic directory structure for the Odin-based chat application. Includes the initial implementation of:
- Core data types (User, Server, Channel, Message) in `shared/types.odin`.
- Basic Raylib client window setup in `client/main.odin`.
- WebSocket server and network message protocol structures in `server/websocket/server.odin` and `shared/protocol/messages.odin`.

This commit establishes the foundation for subsequent development phases, covering the "Getting Started" items from the project plan.