### PR TITLE
feat: Define initial communication protocol

### DIFF
--- a/chat-app/src/shared/protocol/protocol.odin
+++ b/chat-app/src/shared/protocol/protocol.odin
@@ -1,0 +1,115 @@
+package protocol
+
+import "core:time"
+import "../types" // Adjust path as needed based on actual file structure
+
+// MessageType defines the type of a message exchanged between client and server.
+MessageType :: enum {
+    // Client to Server
+    C2S_LOGIN,
+    C2S_SEND_MESSAGE,
+    C2S_JOIN_CHANNEL, // Example: Client requests to join a channel
+    C2S_CREATE_CHANNEL, // Example: Client requests to create a new channel
+
+    // Server to Client
+    S2C_LOGIN_SUCCESS,
+    S2C_LOGIN_FAILURE,
+    S2C_NEW_MESSAGE,
+    S2C_USER_JOINED_CHANNEL, // Example: Server notifies clients that a user joined
+    S2C_CHANNEL_CREATED, // Example: Server notifies clients that a channel was created
+    S2C_ERROR, // Generic error message from server
+}
+
+// BaseMessage is a wrapper for all messages, containing the type.
+// Specific message structs can be included in a union or handled based on type.
+BaseMessage :: struct {
+    type: MessageType,
+}
+
+// C2S_Login_Message is sent by the client to log in.
+C2S_Login_Message :: struct {
+    using base: BaseMessage, // Should be C2S_LOGIN
+    username:   string,
+    password:   string, // Note: Passwords should be hashed in a real application
+}
+
+// S2C_Login_Success_Message is sent by the server on successful login.
+S2C_Login_Success_Message :: struct {
+    using base: BaseMessage, // Should be S2C_LOGIN_SUCCESS
+    user:       types.User,
+    servers:    [dynamic]types.Server, // List of servers the user is part of
+}
+
+// S2C_Login_Failure_Message is sent by the server on failed login.
+S2C_Login_Failure_Message :: struct {
+    using base: BaseMessage, // Should be S2C_LOGIN_FAILURE
+    error_message: string,
+}
+
+// C2S_Send_Message_Message is sent by the client to send a message to a channel.
+C2S_Send_Message_Message :: struct {
+    using base: BaseMessage, // Should be C2S_SEND_MESSAGE
+    channel_id: u64,
+    content:    string,
+    image_path: string, // Optional: path to an image if attached
+}
+
+// S2C_New_Message_Message is broadcast by the server when a new message is posted.
+S2C_New_Message_Message :: struct {
+    using base: BaseMessage, // Should be S2C_NEW_MESSAGE
+    message:    types.Message,
+}
+
+// C2S_Join_Channel_Message is sent by the client to join a specific channel.
+C2S_Join_Channel_Message :: struct {
+    using base: BaseMessage, // Should be C2S_JOIN_CHANNEL
+    channel_id: u64,
+}
+
+// S2C_User_Joined_Channel_Message is sent by the server to notify clients in a channel about a new user.
+S2C_User_Joined_Channel_Message :: struct {
+    using base: BaseMessage, // Should be S2C_USER_JOINED_CHANNEL
+    channel_id: u64,
+    user:       types.User, // The user who joined
+}
+
+// C2S_Create_Channel_Message allows a client to request the creation of a new channel on a server.
+C2S_Create_Channel_Message :: struct {
+    using base: BaseMessage, // Should be C2S_CREATE_CHANNEL
+    server_id:  u64,
+    name:       string,
+}
+
+// S2C_Channel_Created_Message is sent by the server to notify relevant clients that a new channel has been created.
+S2C_Channel_Created_Message :: struct {
+    using base: BaseMessage, // Should be S2C_CHANNEL_CREATED
+    channel:    types.Channel,
+}
+
+// S2C_Error_Message is a generic error message sent by the server.
+S2C_Error_Message :: struct {
+    using base: BaseMessage, // Should be S2C_ERROR
+    error_message: string,
+    original_request_type: MessageType, // Optional: helps client identify context of error
+}
+
+// Helper procedure to create a C2S_Login_Message
+create_c2s_login_message :: proc(username, password: string) -> C2S_Login_Message {
+    return C2S_Login_Message{
+        base = BaseMessage{type = .C2S_LOGIN},
+        username = username,
+        password = password,
+    };
+}
+
+// Helper procedure to create a C2S_Send_Message_Message
+create_c2s_send_message_message :: proc(channel_id: u64, content: string, image_path: string = "") -> C2S_Send_Message_Message {
+    return C2S_Send_Message_Message{
+        base = BaseMessage{type = .C2S_SEND_MESSAGE},
+        channel_id = channel_id,
+        content = content,
+        image_path = image_path,
+    };
+}
+
+// Add more helper procedures for other message types as needed.


### PR DESCRIPTION
I created `chat-app/src/shared/protocol/protocol.odin` to define the basic message types and data structures for client-server communication.

This includes:
- `MessageType` enum for various actions (login, send message, etc.).
- `BaseMessage` struct to wrap all messages.
- Specific message structs for client-to-server (C2S) and server-to-client (S2C) communications, such as:
  - `C2S_Login_Message`, `S2C_Login_Success_Message`, `S2C_Login_Failure_Message`
  - `C2S_Send_Message_Message`, `S2C_New_Message_Message`
  - `C2S_Join_Channel_Message`, `S2C_User_Joined_Channel_Message`
  - `C2S_Create_Channel_Message`, `S2C_Channel_Created_Message`
  - `S2C_Error_Message`
- Helper procedures for creating some of these message types.

The protocol uses types defined in `chat-app/src/shared/types.odin`.