### PR TITLE
Refactor: Remove unused stub client and server files

### DIFF
--- a/client/lightchat.odin
+++ b/client/lightchat.odin
@@ -1,8 +1,0 @@
-package lightchat
-
-import "core:fmt"
-import rl "vendor:raylib"
-
-main::proc() {
-
-}

--- a/server/lightchat-server.odin
+++ b/server/lightchat-server.odin
@@ -1,7 +1,0 @@
-package lightchat
-
-import "core:fmt"
-
-main::proc() {
-
-}


### PR DESCRIPTION
I deleted `client/lightchat.odin` and `server/lightchat-server.odin` as they were identified as empty stubs during my codebase review.

The main application code resides in the `chat-app/` directory. This change cleans up the repository by removing non-functional placeholder files.