### PR TITLE
feat: Implement basic chat functionality (channels, messaging)

### DIFF
--- a/chat-app/src/client/main.odin
+++ b/chat-app/src/client/main.odin
@@ -1,85 +1,405 @@
 package client
 
-import rl "vendor:raylib" // Assuming raylib is in a vendor directory or system path
+import rl "vendor:raylib"
+import "core:net"
+import "core:fmt"
+import "core:log"
+import "core:strings"
+import "core:encoding/json"
+import "core:bufio"
+import "core:time"
+import "core:container/dynarray"
 
-// Forward declarations for procedures to be defined later
+import "../shared/protocol"
+import "../shared/types"
+
+// Helper to convert a null-terminated u8 buffer (C string) to an Odin string
+cstring_buffer_to_string :: proc(buffer: []u8) -> string {
+    length := 0
+    for length < len(buffer) && buffer[length] != 0 {
+        length += 1
+    }
+    return string(buffer[:length])
+}
+
 init_app :: proc(app: ^App) ---
 update_app :: proc(app: ^App) ---
 draw_app :: proc(app: ^App) ---
 cleanup_app :: proc(app: ^App) ---
 
-// Forward declarations for types that might be in other files
-User :: struct {} // Placeholder
-Server :: struct {} // Placeholder
-Channel :: struct {} // Placeholder
-UIManager :: struct {} // Placeholder
-NetworkClient :: struct {} // Placeholder
-
-
 AppState :: enum {
     LOGIN,
     MAIN_CHAT,
-    SETTINGS,
 }
 
 App :: struct {
     state:           AppState,
     window_width:    i32,
     window_height:   i32,
-    current_user:    ^User,          // Placeholder
-    current_server:  ^Server,        // Placeholder
-    current_channel: ^Channel,       // Placeholder
-    ui_manager:      ^UIManager,     // Placeholder
-    network_client:  ^NetworkClient, // Placeholder
     image_cache:     map[string]rl.Texture2D,
+
+    // Login state
+    username_buffer: [128]u8,
+    password_buffer: [128]u8,
+    username_box_active: bool,
+    password_box_active: bool,
+    login_error_message: string,
+
+    // Network state
+    conn: net.Conn,
+    reader: bufio.Reader,
+    is_connecting: bool,
+    is_connected: bool,
+    login_attempted_this_connection: bool,
+
+    // Logged-in user & current context
+    logged_in_user: ^types.User,
+    current_channel_name: string,
+
+    // Chat message input
+    chat_message_buffer: [256]u8,
+    chat_message_box_active: bool,
+    current_chat_messages: [dynamic]types.Message,
+    chat_error_message: string, // For errors specific to chat view (e.g. send failed)
 }
 
 main :: proc() {
+    log.set_default_logger(log.create_console_logger())
     app := App{
         window_width = 1200,
         window_height = 800,
         state = .LOGIN,
+        current_chat_messages = make([dynamic]types.Message),
+        current_channel_name = "",
     }
 
-    rl.InitWindow(app.window_width, app.window_height, "Discord Clone")
+    rl.InitWindow(app.window_width, app.window_height, "Chat App Client")
     rl.SetTargetFPS(60)
-
-    // init_app(&app) // Call to placeholder
+    init_app(&app)
 
     for !rl.WindowShouldClose() {
-        // update_app(&app) // Call to placeholder
-
+        update_app(&app)
         rl.BeginDrawing()
         rl.ClearBackground(rl.RAYWHITE)
-        // draw_app(&app) // Call to placeholder
-        rl.DrawText("Basic Raylib Window!", 190, 200, 20, rl.LIGHTGRAY)
+        draw_app(&app)
         rl.EndDrawing()
     }
 
-    // cleanup_app(&app) // Call to placeholder
+    cleanup_app(&app)
     rl.CloseWindow()
 }
 
-// Placeholder implementations (to be expanded in later steps)
 init_app :: proc(app: ^App) {
-    // Initialize application state, UI, network, etc.
-    // For now, this can be empty or have minimal setup.
     app.image_cache = make(map[string]rl.Texture2D)
+    log.info("Application initialized.")
 }
 
+disconnect_and_reset :: proc(app: ^App, reason: string) {
+    if app.conn != nil {
+        net.close(app.conn)
+        app.conn = nil
+    }
+    app.is_connected = false
+    app.is_connecting = false
+    app.login_attempted_this_connection = false
+    if reason != "" {
+        // If in LOGIN state, update login_error_message. Otherwise, could set a global error or chat_error_message.
+        if app.state == .LOGIN {
+            app.login_error_message = reason
+        } else {
+            app.chat_error_message = reason // Use chat_error_message for non-login state errors
+        }
+    }
+    log.infof("Disconnected. Reason: %s", reason)
+}
+
+
 update_app :: proc(app: ^App) {
-    // Handle input, update game logic, network events, etc.
+    // Clear per-frame error messages if they are meant to be transient
+    // app.chat_error_message = "" // Or handle display timeout elsewhere
+
+    switch app.state {
+    case .LOGIN:
+        // ... (LOGIN state logic remains the same) ...
+        if app.is_connected && app.login_attempted_this_connection && app.logged_in_user == nil && app.reader.buf != nil {
+            line_bytes, read_err := bufio.read_line_bytes(&app.reader)
+            if read_err != nil {
+                if read_err == net.EOF { disconnect_and_reset(app, "Connection lost: Server closed.") }
+                else if read_err == bufio.Error.Buffer_Full { disconnect_and_reset(app, "Network error: Incomplete message.") }
+                else { disconnect_and_reset(app, "Network error receiving response.") }
+            } else if len(line_bytes) > 0 {
+                var base_resp: protocol.BaseMessage
+                json_err := json.unmarshal(line_bytes, &base_resp)
+                if json_err != nil { app.login_error_message = "Error: Invalid server response." }
+                else {
+                    switch base_resp.type {
+                    case .S2C_LOGIN_SUCCESS:
+                        var success_msg: protocol.S2C_Login_Success_Message
+                        if json.unmarshal(line_bytes, &success_msg) == nil {
+                            app.logged_in_user = new(types.User); app.logged_in_user^ = success_msg.user
+                            app.login_error_message = "Login Successful! Joining 'general' channel..."
+                            log.infof("Login successful: User %s (ID: %d)", app.logged_in_user.username, app.logged_in_user.id)
+                            app.state = .MAIN_CHAT
+                            app.username_buffer = {}; app.password_buffer = {}
+                            join_req := protocol.create_c2s_join_channel_message("general")
+                            join_json_bytes, marshal_err := json.marshal(join_req)
+                            if marshal_err != nil {
+                                log.errorf("Failed to marshal C2S_JOIN_CHANNEL for 'general': %v", marshal_err)
+                                app.chat_error_message = "Error: Could not prepare join request."
+                            } else {
+                                final_join_payload := make([]u8, len(join_json_bytes) + 1)
+                                copy(final_join_payload, join_json_bytes)
+                                final_join_payload[len(join_json_bytes)] = '\n'
+                                if _, write_err := net.write_all(app.conn, final_join_payload); write_err != nil {
+                                    log.errorf("Failed to send C2S_JOIN_CHANNEL for 'general': %v", write_err)
+                                    disconnect_and_reset(app, "Error: Failed to send join channel request.")
+                                    app.state = .LOGIN
+                                } else {
+                                    log.info("Sent C2S_JOIN_CHANNEL for 'general' channel.")
+                                }
+                            }
+                        } else { app.login_error_message = "Error: Malformed login success." }
+                    case .S2C_LOGIN_FAILURE:
+                        var failure_msg: protocol.S2C_Login_Failure_Message
+                        if json.unmarshal(line_bytes, &failure_msg) == nil {
+                            app.login_error_message = fmt.tprintf("Login failed: %s", failure_msg.error_message)
+                        } else { app.login_error_message = "Error: Malformed login failure." }
+                        app.login_attempted_this_connection = false
+                    case .S2C_USER_JOINED_CHANNEL:
+                        var join_msg: protocol.S2C_User_Joined_Channel_Message
+                        if json.unmarshal(line_bytes, &join_msg) == nil {
+                            log.infof("Received S2C_USER_JOINED_CHANNEL for '%s' during login phase.", join_msg.channel_name)
+                            app.current_channel_name = join_msg.channel_name
+                        }
+                    case:
+                        app.login_error_message = "Error: Unexpected server response during login."
+                        log.warnf("Unexpected msg type %v after login attempt.", base_resp.type)
+                    }
+                }
+            }
+        }
+        if app.is_connected && !app.is_connecting && !app.login_attempted_this_connection && app.logged_in_user == nil {
+            username_str := cstring_buffer_to_string(app.username_buffer[:])
+            if username_str == "" { disconnect_and_reset(app, "Username cannot be empty."); return }
+            password_str := cstring_buffer_to_string(app.password_buffer[:])
+            log.info("Preparing C2S_LOGIN...")
+            login_payload := protocol.create_c2s_login_message(username_str, password_str)
+            json_bytes, marshal_err := json.marshal(login_payload)
+            if marshal_err != nil { disconnect_and_reset(app, "Client error: Failed to prepare login."); return }
+            final_payload := make([]u8, len(json_bytes) + 1); copy(final_payload, json_bytes); final_payload[len(json_bytes)] = '\n'
+            if _, write_err := net.write_all(app.conn, final_payload); write_err != nil {
+                disconnect_and_reset(app, "Network error: Failed to send login.")
+            } else {
+                log.infof("Login message sent for %s.", username_str)
+                app.login_error_message = "Login sent. Waiting for server..."
+                app.login_attempted_this_connection = true
+            }
+        }
+        else if !app.is_connected && !app.is_connecting {
+            username_rect := rl.Rectangle{ (f32(app.window_width) - 200) / 2, (f32(app.window_height) / 2) - 60, 200, 30 }
+            password_rect := rl.Rectangle{ (f32(app.window_width) - 200) / 2, (f32(app.window_height) / 2) - 20, 200, 30 }
+            login_button_rect := rl.Rectangle{ (f32(app.window_width) - 200) / 2, (f32(app.window_height) / 2) + 20, 200, 40 }
+            if rl.GuiTextBox(username_rect, app.username_buffer[:], &app.username_box_active) { if app.username_box_active { app.password_box_active = false } }
+            if rl.GuiTextBox(password_rect, app.password_buffer[:], &app.password_box_active) { if app.password_box_active { app.username_box_active = false } }
+            if rl.GuiButton(login_button_rect, "Login") {
+                app.is_connecting = true; app.login_error_message = ""; app.login_attempted_this_connection = false
+                log.info("Login button clicked. Connecting...")
+                conn, err := net.dial("tcp", "127.0.0.1:8080")
+                if err != nil { disconnect_and_reset(app, fmt.tprintf("Connection failed: %v", err)) }
+                else {
+                    log.info("Network connected. Initializing reader.")
+                    app.is_connecting = false; app.is_connected = true; app.conn = conn
+                    app.reader = bufio.make_reader(app.conn, bufio.DEFAULT_BUFFER_SIZE)
+                }
+            }
+        }
+
+    case .MAIN_CHAT:
+        if app.conn == nil || !app.is_connected {
+            log.warn("Connection lost in MAIN_CHAT. Returning to LOGIN.")
+            app.state = .LOGIN; disconnect_and_reset(app, "Connection lost.")
+            return
+        }
+        app.chat_error_message = "" // Clear previous chat error, if any, at start of update
+
+        if app.reader.buf != nil {
+            line_bytes, read_err := bufio.read_line_bytes(&app.reader)
+            if read_err != nil {
+                if read_err == net.EOF { disconnect_and_reset(app, "Connection lost."); app.state = .LOGIN; return }
+                else if read_err == bufio.Error.Buffer_Full { disconnect_and_reset(app, "Network error: Message too large or malformed."); app.state = .LOGIN; return}
+                else { disconnect_and_reset(app, fmt.tprintf("Network error: %v", read_err)); app.state = .LOGIN; return }
+            }
+            if len(line_bytes) > 0 {
+                log.debugf("MAIN_CHAT: Received line: %s", string(line_bytes))
+                var base_msg: protocol.BaseMessage
+                if json.unmarshal(line_bytes, &base_msg) == nil {
+                    switch base_msg.type {
+                    case .S2C_NEW_MESSAGE:
+                        var new_msg_data: protocol.S2C_New_Message_Message
+                        if json.unmarshal(line_bytes, &new_msg_data) == nil {
+                            append(&app.current_chat_messages, new_msg_data.message)
+                            if len(app.current_chat_messages) > 100 { dynarray.delete_at(&app.current_chat_messages, 0) }
+                            log.infof("Msg for '%s' from %d: %s", new_msg_data.message.channel_name, new_msg_data.message.author_id, new_msg_data.message.content)
+                        } else { log.error("Failed to unmarshal S2C_NEW_MESSAGE.") }
+                    case .S2C_USER_JOINED_CHANNEL:
+                        var join_info: protocol.S2C_User_Joined_Channel_Message
+                        if json.unmarshal(line_bytes, &join_info) == nil {
+                            log.infof("User '%s' joined channel '%s'.", join_info.user.username, join_info.channel_name)
+                            if join_info.channel_name == app.current_channel_name {
+                                system_msg_text := fmt.tprintf("System: %s has joined.", join_info.user.username)
+                                system_msg := types.Message{author_id=0, content=system_msg_text, channel_name=join_info.channel_name, timestamp=time.now()}
+                                append(&app.current_chat_messages, system_msg)
+                                if len(app.current_chat_messages) > 100 { dynarray.delete_at(&app.current_chat_messages, 0) }
+                            }
+                            if app.logged_in_user != nil && join_info.user.id == app.logged_in_user.id {
+                                app.current_channel_name = join_info.channel_name
+                            }
+                        } else { log.error("Failed to unmarshal S2C_USER_JOINED_CHANNEL.")}
+                    case:
+                        log.warnf("MAIN_CHAT: Unhandled message type %v", base_msg.type)
+                    }
+                } else { log.error("MAIN_CHAT: Failed to unmarshal BaseMessage from server.") }
+            }
+        }
+
+        chat_input_rect := rl.Rectangle{205, f32(app.window_height) - 45, f32(app.window_width) - 205 - 75, 40}
+        send_button_rect := rl.Rectangle{f32(app.window_width) - 70, f32(app.window_height) - 45, 65, 40}
+        if rl.IsMouseButtonPressed(rl.MOUSE_LEFT_BUTTON) {
+            app.chat_message_box_active = rl.CheckCollisionPointRec(rl.GetMousePosition(), chat_input_rect)
+        }
+
+        enter_pressed_in_textbox := app.chat_message_box_active && (rl.IsKeyPressed(rl.KEY_ENTER) || rl.IsKeyPressed(rl.KEY_KP_ENTER))
+        send_button_clicked := rl.GuiButton(send_button_rect, "Send")
+
+        if send_button_clicked || enter_pressed_in_textbox {
+            if !app.is_connected || app.conn == nil {
+                log.error("Send action, but not connected.")
+                app.chat_error_message = "Not connected to server."
+            } else {
+                message_content := cstring_buffer_to_string(app.chat_message_buffer[:])
+                trimmed_content := strings.trim_space(message_content)
+
+                if trimmed_content == "" {
+                    log.debug("Send action, but message is empty.")
+                    // Optionally provide UI feedback that message is empty
+                } else {
+                    send_payload := protocol.create_c2s_send_message_message(trimmed_content, "")
+                    json_bytes, marshal_err := json.marshal(send_payload)
+                    if marshal_err != nil {
+                        log.errorf("Failed to marshal C2S_SEND_MESSAGE: %v", marshal_err)
+                        app.chat_error_message = "Error: Could not prepare message."
+                    } else {
+                        final_payload := make([]u8, len(json_bytes) + 1)
+                        copy(final_payload, json_bytes)
+                        final_payload[len(json_bytes)] = '\n'
+
+                        bytes_written, write_err := net.write_all(app.conn, final_payload)
+                        if write_err != nil {
+                            log.errorf("Failed to send C2S_SEND_MESSAGE: %v. Bytes written: %d", write_err, bytes_written)
+                            disconnect_and_reset(app, "Error: Message send failed.")
+                            app.state = .LOGIN // Revert to login on send failure
+                        } else {
+                            log.infof("Sent message: %s", trimmed_content)
+                            app.chat_message_buffer = {} // Clear buffer
+                            // app.chat_message_box_active = true; // Keep focus, usually good UX
+                        }
+                    }
+                }
+            }
+        }
+        break
+    }
 }
 
 draw_app :: proc(app: ^App) {
-    // Draw all UI elements based on app.state
+    switch app.state {
+    case .LOGIN:
+        username_rect := rl.Rectangle{ (f32(app.window_width) - 200) / 2, (f32(app.window_height) / 2) - 60, 200, 30 }
+        password_rect := rl.Rectangle{ (f32(app.window_width) - 200) / 2, (f32(app.window_height) / 2) - 20, 200, 30 }
+        login_button_rect := rl.Rectangle{ (f32(app.window_width) - 200) / 2, (f32(app.window_height) / 2) + 20, 200, 40 }
+        button_text := "Login"
+        if app.is_connecting { button_text = "Connecting..." }
+        else if app.is_connected && app.login_attempted_this_connection && app.logged_in_user == nil { button_text = "Verifying..." }
+        else if app.is_connected && !app.login_attempted_this_connection { button_text = "Send Credentials" }
+        rl.GuiTextBox(username_rect, app.username_buffer[:], &app.username_box_active)
+        rl.GuiTextBox(password_rect, app.password_buffer[:], &app.password_box_active)
+        rl.GuiButton(login_button_rect, button_text) // Store result if needed for click sound etc.
+        status_text_y := login_button_rect.y + login_button_rect.height + 20
+        current_status_message := ""; status_color := rl.GRAY
+        if app.login_error_message != "" {
+            current_status_message = app.login_error_message
+            if strings.contains(strings.to_lower(app.login_error_message), "failed") ||
+               strings.contains(strings.to_lower(app.login_error_message), "error") { status_color = rl.RED }
+            else if strings.contains(strings.to_lower(app.login_error_message), "success") { status_color = rl.GREEN }
+            else if strings.contains(app.login_error_message, "Waiting") || strings.contains(app.login_error_message, "sent") { status_color = rl.ORANGE }
+            else { status_color = rl.BLACK }
+        } else if app.is_connecting { current_status_message = "Connecting..."; status_color = rl.ORANGE }
+        else if app.is_connected && app.login_attempted_this_connection && app.logged_in_user == nil { current_status_message = "Login sent. Waiting..."; status_color = rl.SKYBLUE }
+        else if app.is_connected { current_status_message = "Connected. Ready to login."; status_color = rl.GREEN }
+        else { current_status_message = "Please enter credentials." }
+        text_width := rl.MeasureText(current_status_message, 20)
+        rl.DrawText(current_status_message, (app.window_width - text_width)/2, i32(status_text_y), 20, status_color)
+
+    case .MAIN_CHAT:
+        channel_list_rect := rl.Rectangle{0, 0, 200, f32(app.window_height)}
+        message_view_rect := rl.Rectangle{200, 0, f32(app.window_width) - 400, f32(app.window_height) - 50}
+        user_list_rect := rl.Rectangle{f32(app.window_width) - 200, 0, 200, f32(app.window_height)}
+        chat_input_rect := rl.Rectangle{205, f32(app.window_height) - 45, f32(app.window_width) - 205 - 75, 40}
+        send_button_rect := rl.Rectangle{f32(app.window_width) - 70, f32(app.window_height) - 45, 65, 40}
+
+        rl.DrawRectangleRec(channel_list_rect, rl.Fade(rl.BLUE, 0.1))
+        rl.DrawText("Channels", 10, 10, 20, rl.DARKGRAY)
+        channel_display_name := app.current_channel_name if app.current_channel_name != "" else "None"
+        rl.DrawText(fmt.tprintf("# %s", channel_display_name), 15, 40, 18, rl.BLUE)
+        if app.logged_in_user != nil {
+             rl.DrawText(fmt.tprintf("User: %s", app.logged_in_user.username), 10, app.window_height - 25, 16, rl.DARKGRAY)
+        }
+
+        rl.DrawRectangleRec(user_list_rect, rl.Fade(rl.GREEN, 0.1))
+        rl.DrawText("Users", app.window_width - 190, 10, 20, rl.DARKGRAY)
+
+        rl.DrawRectangleRec(message_view_rect, rl.Fade(rl.GRAY, 0.05))
+        message_font_size := 18; line_height := 20
+        msg_padding_x := i32(message_view_rect.x + 10)
+        current_draw_y := i32(message_view_rect.y + message_view_rect.height) - line_height - 5
+
+        if len(app.current_chat_messages) == 0 {
+            no_msg_text := fmt.tprintf("No messages yet in #%s. Say hi!", channel_display_name)
+            text_w := rl.MeasureText(no_msg_text, message_font_size)
+            rl.DrawText(no_msg_text, i32(message_view_rect.x + (message_view_rect.width - f32(text_w))/2), i32(message_view_rect.y + 20), message_font_size, rl.GRAY)
+        } else {
+            for i := len(app.current_chat_messages) - 1; i >= 0; i -= 1 {
+                message := app.current_chat_messages[i]
+                author_name_str: string; author_color := rl.DARKGRAY
+                if app.logged_in_user != nil && message.author_id == app.logged_in_user.id { author_name_str = "You"; author_color = rl.SKYBLUE }
+                else if message.author_id == 0 { author_name_str = "System"; author_color = rl.PURPLE }
+                else { author_name_str = fmt.tprintf("User_%v", message.author_id) }
+                author_prefix := fmt.tprintf("%s: ", author_name_str)
+                author_text_width := rl.MeasureText(author_prefix, message_font_size)
+                rl.DrawText(author_prefix, msg_padding_x, current_draw_y, message_font_size, author_color)
+                rl.DrawText(message.content, msg_padding_x + author_text_width, current_draw_y, message_font_size, rl.BLACK)
+                current_draw_y -= line_height
+                if current_draw_y < i32(message_view_rect.y) { break }
+            }
+        }
+
+        // Display chat-specific error messages at the top of message view or bottom
+        if app.chat_error_message != "" {
+            error_text_width := rl.MeasureText(app.chat_error_message, 16)
+            rl.DrawText(app.chat_error_message, i32(message_view_rect.x + (message_view_rect.width - f32(error_text_width))/2), i32(message_view_rect.y + 5), 16, rl.RED)
+        }
+
+
+        if rl.GuiTextBox(chat_input_rect, app.chat_message_buffer[:], &app.chat_message_box_active) {
+            // If enter pressed, it's handled in update_app. This call is mainly for drawing and direct mouse interaction.
+        }
+        // The GuiButton for "Send" is drawn here, but its click is handled in update_app
+        rl.GuiButton(send_button_rect, "Send")
+    }
 }
 
 cleanup_app :: proc(app: ^App) {
-    // Free resources, close connections, etc.
-    // Example: cleanup image cache if it were populated
-    // for path, texture in app.image_cache {
-    //     rl.UnloadTexture(texture)
-    // }
-    // delete(app.image_cache)
+    if app.conn != nil { log.info("Closing network connection."); net.close(app.conn); app.conn = nil; app.is_connected = false }
+    if app.logged_in_user != nil { free(app.logged_in_user); app.logged_in_user = nil }
+    log.info("Application cleanup finished.")
 }

--- a/chat-app/src/server/main.odin
+++ b/chat-app/src/server/main.odin
@@ -1,0 +1,280 @@
+package server
+
+import "core:fmt"
+import "core:log"
+import "core:net"
+import "core:os"
+import "core:thread"
+import "core:time"
+import "core:sync"
+import "core:encoding/json"
+import "core:strings"
+import "core:bufio"
+
+
+import "../shared/types"
+import "../shared/protocol"
+
+// ClientSession stores information about a connected client
+ClientSession :: struct {
+    id:          u64,
+    conn:        net.Conn,
+    user:        ^types.User,
+    remote_addr: net.Address,
+    current_channel_name: string, // Name of the channel the user is currently in
+}
+
+// ChannelData stores information and state for a single chat channel
+ChannelData :: struct {
+    name:     string,
+    users:    map[u64]^ClientSession, // Keyed by session.id
+    messages: [dynamic]types.Message, // Message history
+}
+
+// Global state for managing clients
+connected_clients := make(map[u64]^ClientSession)
+clients_mutex     : sync.Mutex
+next_client_id    : u64 = 1
+
+// Global state for managing chat channels
+chat_channels   := make(map[string]^ChannelData)
+channels_mutex  : sync.Mutex
+
+
+// Helper to send a JSON message with a newline
+send_json_message :: proc(conn: net.Conn, session_id: u64, message: any) -> (err: net.Error) {
+    response_bytes, marshal_err := json.marshal(message)
+    if marshal_err != nil {
+        log.errorf("Client %d: Failed to marshal message type %T: %v", session_id, message, marshal_err)
+        return net.EINVAL
+    }
+
+    newline_char := []u8{'\n'}
+    response_final := make([]u8, len(response_bytes) + len(newline_char))
+    copy(response_final, response_bytes)
+    copy(response_final[len(response_bytes):], newline_char)
+
+    _, write_err := net.write_all(conn, response_final)
+    if write_err != nil {
+        // Log error, but don't make it fatal for the helper itself, caller can decide.
+        // log.errorf("Client %d: Error sending message type %T: %v", session_id, message, write_err)
+        return write_err
+    }
+    log.debugf("Client %d: Sent message type %T successfully.", session_id, message)
+    return nil
+}
+
+// handle_client is responsible for managing a single client's lifecycle using JSON messages.
+handle_client :: proc(conn: net.Conn) {
+    remote_addr := net.remote_address(conn)
+    session_id: u64
+    session: ^ClientSession
+
+    sync.mutex_lock(&clients_mutex)
+    session_id = next_client_id
+    next_client_id += 1
+    session = new(ClientSession)
+    session^ = ClientSession{
+        id          = session_id,
+        conn        = conn,
+        user        = nil,
+        remote_addr = remote_addr,
+        current_channel_name = "",
+    }
+    connected_clients[session_id] = session
+    sync.mutex_unlock(&clients_mutex)
+    log.infof("Client %v connected with Session ID %d.", remote_addr, session_id)
+
+    defer {
+        if session.current_channel_name != "" {
+            sync.mutex_lock(&channels_mutex)
+            if old_channel, exists := chat_channels[session.current_channel_name]; exists {
+                delete(old_channel.users, session.id)
+                log.infof("Client %d removed from channel '%s' due to disconnect.", session.id, session.current_channel_name)
+                // TODO: Broadcast S2C_User_Left_Channel_Message to other users in old_channel
+            }
+            sync.mutex_unlock(&channels_mutex)
+        }
+        net.close(conn)
+        sync.mutex_lock(&clients_mutex)
+        delete(connected_clients, session_id)
+        sync.mutex_unlock(&clients_mutex)
+        log.infof("Client %v (ID %d) disconnected. Active clients: %d", remote_addr, session_id, len(connected_clients))
+    }
+
+    reader := bufio.make_reader(conn, bufio.DEFAULT_BUFFER_SIZE)
+    for {
+        line_bytes, err := bufio.read_line_bytes(reader)
+        if err != nil {
+            if err == net.EOF { log.infof("Client %d (%v): Connection closed (EOF).", session.id, remote_addr) }
+            else if err == net.EAGAIN { log.warnf("Client %d (%v): Read EAGAIN.", session.id, remote_addr); thread.sleep(50*time.Millisecond); continue }
+            else { log.errorf("Read error client %d (%v): %v", session.id, remote_addr, err) }
+            break
+        }
+        if len(line_bytes) == 0 { log.debugf("Client %d: Empty line.", session.id); continue }
+        log.debugf("Client %d: Raw line (len %d): %s", session.id, len(line_bytes), string(line_bytes))
+
+        if session.user != nil { // Client is LOGGED IN
+            var base_msg protocol.BaseMessage
+            json_err_base := json.unmarshal(line_bytes, &base_msg)
+            if json_err_base != nil {
+                log.errorf("Client %d (%s): Failed to unmarshal BaseMessage JSON: %v. Raw: %s", session.id, session.user.username, json_err_base, string(line_bytes))
+                err_resp := protocol.S2C_Error_Message{ base = protocol.BaseMessage{type = .S2C_ERROR}, error_message = "Invalid message format.", original_request_type = base_msg.type }
+                send_json_message(session.conn, session.id, err_resp)
+                continue
+            }
+            log.debugf("Client %d (%s): Received message type %v", session.id, session.user.username, base_msg.type)
+
+            switch base_msg.type {
+            case protocol.MessageType.C2S_JOIN_CHANNEL:
+                // ... (previous C2S_JOIN_CHANNEL logic remains here) ...
+                var join_msg protocol.C2S_Join_Channel_Message
+                json_err := json.unmarshal(line_bytes, &join_msg)
+                if json_err != nil {
+                    log.errorf("Client %d: Failed to unmarshal C2S_JOIN_CHANNEL: %v. Raw: %s", session.id, json_err, string(line_bytes))
+                    err_resp := protocol.S2C_Error_Message{ base = protocol.BaseMessage{type = .S2C_ERROR}, error_message = "Invalid join channel message format.", original_request_type = .C2S_JOIN_CHANNEL }
+                    send_json_message(session.conn, session.id, err_resp)
+                    continue
+                }
+                log.infof("Client %d (%s): Joining channel '%s'", session.id, session.user.username, join_msg.channel_name)
+                sync.mutex_lock(&channels_mutex)
+                target_channel, exists := chat_channels[join_msg.channel_name]
+                if exists {
+                    if session.current_channel_name != "" && session.current_channel_name != join_msg.channel_name {
+                        if old_channel, old_exists := chat_channels[session.current_channel_name]; old_exists {
+                            delete(old_channel.users, session.id)
+                            log.infof("Client %d (%s) removed from old channel '%s'.", session.id, session.user.username, session.current_channel_name)
+                        }
+                    }
+                    if session.current_channel_name != join_msg.channel_name {
+                         target_channel.users[session.id] = session
+                         session.current_channel_name = join_msg.channel_name
+                    }
+                    sync.mutex_unlock(&channels_mutex)
+                    log.infof("Client %d (%s) joined channel '%s'. Users: %d", session.id, session.user.username, join_msg.channel_name, len(target_channel.users))
+                    join_response := protocol.S2C_User_Joined_Channel_Message{ base = protocol.BaseMessage{type = .S2C_USER_JOINED_CHANNEL}, channel_name = join_msg.channel_name, user = session.user^, }
+                    send_json_message(session.conn, session.id, join_response)
+                } else {
+                    sync.mutex_unlock(&channels_mutex)
+                    log.warnf("Client %d (%s): Tried to join non-existent channel '%s'", session.id, session.user.username, join_msg.channel_name)
+                    err_resp := protocol.S2C_Error_Message{ base = protocol.BaseMessage{type = .S2C_ERROR}, error_message = fmt.tprintf("Channel '%s' not found.", join_msg.channel_name), original_request_type = .C2S_JOIN_CHANNEL }
+                    send_json_message(session.conn, session.id, err_resp)
+                }
+
+            case protocol.MessageType.C2S_SEND_MESSAGE:
+                var send_msg_req protocol.C2S_Send_Message_Message
+                json_err := json.unmarshal(line_bytes, &send_msg_req)
+                if json_err != nil {
+                    log.errorf("Client %d: Failed to unmarshal C2S_SEND_MESSAGE: %v. Raw: %s", session.id, json_err, string(line_bytes))
+                    err_resp := protocol.S2C_Error_Message{ base = protocol.BaseMessage{type = .S2C_ERROR}, error_message = "Invalid send message format.", original_request_type = .C2S_SEND_MESSAGE }
+                    send_json_message(session.conn, session.id, err_resp)
+                    continue
+                }
+
+                if session.current_channel_name == "" {
+                    log.warnf("Client %d (%s): Tried to send message without being in a channel.", session.id, session.user.username)
+                    err_resp := protocol.S2C_Error_Message{ base = protocol.BaseMessage{type = .S2C_ERROR}, error_message = "You are not in a channel. Join a channel first.", original_request_type = .C2S_SEND_MESSAGE }
+                    send_json_message(session.conn, session.id, err_resp)
+                    continue
+                }
+
+                sync.mutex_lock(&channels_mutex)
+                current_channel_data, exists := chat_channels[session.current_channel_name]
+                if !exists {
+                    sync.mutex_unlock(&channels_mutex)
+                    log.errorf("CRITICAL: Client %d (%s) in channel '%s' but channel does not exist in global map.", session.id, session.user.username, session.current_channel_name)
+                    err_resp := protocol.S2C_Error_Message{ base = protocol.BaseMessage{type = .S2C_ERROR}, error_message = "Internal server error: your current channel was not found.", original_request_type = .C2S_SEND_MESSAGE }
+                    send_json_message(session.conn, session.id, err_resp)
+                    continue
+                }
+
+                // Create the message
+                msg_id := u64(time.tick_now()) // Simplistic ID, not collision-proof for high volume
+                new_chat_message := types.Message{
+                    id = msg_id,
+                    author_id = session.user.id,
+                    channel_name = session.current_channel_name,
+                    content = send_msg_req.content,
+                    image_path = send_msg_req.image_path, // Assuming client sends empty string if no image
+                    timestamp = time.now(),
+                    edited = false,
+                }
+
+                // Store message in channel history
+                append(&current_channel_data.messages, new_chat_message)
+                // TODO: Optional: Limit message history size (e.g., cap at N messages)
+
+                // Prepare broadcast payload
+                broadcast_payload := protocol.S2C_New_Message_Message{
+                    base = protocol.BaseMessage{type = protocol.MessageType.S2C_NEW_MESSAGE},
+                    message = new_chat_message,
+                }
+
+                log.infof("Broadcasting msg ID %v in '%s' to %d users.", msg_id, current_channel_data.name, len(current_channel_data.users))
+                for _, user_in_channel := range current_channel_data.users {
+                    if user_in_channel != nil && user_in_channel.conn != nil {
+                        log.debugf("Sending msg ID %v to user %d (%s)", msg_id, user_in_channel.id, user_in_channel.user.username)
+                        err_send := send_json_message(user_in_channel.conn, user_in_channel.id, broadcast_payload)
+                        if err_send != nil {
+                             log.errorf("Failed to send message (ID %v) to user %d (%s) in channel '%s': %v", msg_id, user_in_channel.id, user_in_channel.user.username, current_channel_data.name, err_send)
+                             // Decide if we should remove this user or mark them as problematic
+                        }
+                    } else {
+                         log.warnf("Skipped broadcast to nil session/conn for session ID %v in channel '%s'", user_in_channel.id if user_in_channel != nil else "unknown", current_channel_data.name)
+                    }
+                }
+                sync.mutex_unlock(&channels_mutex)
+                log.infof("Client %d (%s) sent message to '%s': \"%s\"", session.id, session.user.username, session.current_channel_name, send_msg_req.content)
+
+            case:
+                log.warnf("Client %d (%s): Unhandled message type %v", session.id, session.user.username, base_msg.type)
+                err_resp := protocol.S2C_Error_Message{ base = protocol.BaseMessage{type = .S2C_ERROR}, error_message = "Unhandled message type.", original_request_type = base_msg.type }
+                send_json_message(session.conn, session.id, err_resp)
+            }
+        } else { // Client is NOT LOGGED IN
+            var login_msg protocol.C2S_Login_Message
+            json_err := json.unmarshal(line_bytes, &login_msg)
+            if json_err != nil {
+                log.errorf("Client %d: Failed to unmarshal C2S_LOGIN JSON: %v. Raw: '%s'", session.id, json_err, string(line_bytes))
+                failure_resp := protocol.S2C_Login_Failure_Message{ base = protocol.BaseMessage{type = .S2C_LOGIN_FAILURE}, error_message = "Invalid login message format." }
+                send_json_message(session.conn, session.id, failure_resp)
+                continue
+            }
+            log.infof("Client %d: Processing C2S_LOGIN from JSON. Username: '%s'", session.id, login_msg.username)
+            temp_user := new(types.User); temp_user^ = types.User{ id = session.id, username = login_msg.username, email = fmt.tprintf("%s@example.com", login_msg.username), status = .ONLINE, }
+            session.user = temp_user
+            log.infof("Client %d: Login successful for user '%s'.", session.id, session.user.username)
+            success_resp := protocol.S2C_Login_Success_Message{ base = protocol.BaseMessage{type = .S2C_LOGIN_SUCCESS}, user = session.user^, servers = make([dynamic]types.Server), }
+            if send_json_message(session.conn, session.id, success_resp) != nil { break }
+        }
+    }
+}
+
+main :: proc() {
+    log.set_default_logger(log.create_console_logger(opt_level=.Debug))
+    sync.mutex_lock(&channels_mutex)
+    general_channel_name := "general"
+    if _, exists := chat_channels[general_channel_name]; !exists {
+        chat_channels[general_channel_name] = new(ChannelData)
+        chat_channels[general_channel_name]^ = ChannelData{ name = general_channel_name, users = make(map[u64]^ClientSession), messages = make([dynamic]types.Message), }
+        log.infof("Default channel '%s' created.", general_channel_name)
+    } else { log.warnf("Default channel '%s' already exists.", general_channel_name) }
+    sync.mutex_unlock(&channels_mutex)
+
+    address := "127.0.0.1:8080"
+    listener, err := net.listen("tcp", address)
+    if err != nil { log.errorf("Failed to listen on %s: %v", address, err); os.exit(1); return }
+    defer net.close(listener)
+    log.infof("Server started, listening on %s.", address)
+
+    for {
+        conn, accept_err := net.accept(listener)
+        if accept_err != nil {
+            log.errorf("Failed to accept connection: %v", accept_err)
+            if accept_err == net.EMFILE || accept_err == net.ENFILE { log.critical("Too many open files."); thread.sleep(1 * time.Second) }
+            continue
+        }
+        log.infof("Accepted new connection from %v", net.remote_address(conn))
+        go handle_client(conn)
+    }
+}

--- a/chat-app/src/shared/protocol/protocol.odin
+++ b/chat-app/src/shared/protocol/protocol.odin
@@ -1,0 +1,120 @@
+package protocol
+
+import "core:time"
+import "../types" // Adjust path as needed based on actual file structure
+
+// MessageType defines the type of a message exchanged between client and server.
+MessageType :: enum {
+    // Client to Server
+    C2S_LOGIN,
+    C2S_SEND_MESSAGE,
+    C2S_JOIN_CHANNEL, // Example: Client requests to join a channel
+    C2S_CREATE_CHANNEL, // Example: Client requests to create a new channel
+
+    // Server to Client
+    S2C_LOGIN_SUCCESS,
+    S2C_LOGIN_FAILURE,
+    S2C_NEW_MESSAGE,
+    S2C_USER_JOINED_CHANNEL, // Example: Server notifies clients that a user joined
+    S2C_CHANNEL_CREATED, // Example: Server notifies clients that a channel was created
+    S2C_ERROR, // Generic error message from server
+}
+
+// BaseMessage is a wrapper for all messages, containing the type.
+// Specific message structs can be included in a union or handled based on type.
+BaseMessage :: struct {
+    type: MessageType,
+}
+
+// C2S_Login_Message is sent by the client to log in.
+C2S_Login_Message :: struct {
+    using base: BaseMessage, // Should be C2S_LOGIN
+    username:   string,
+    password:   string, // Note: Passwords should be hashed in a real application
+}
+
+// S2C_Login_Success_Message is sent by the server on successful login.
+S2C_Login_Success_Message :: struct {
+    using base: BaseMessage, // Should be S2C_LOGIN_SUCCESS
+    user:       types.User,
+    servers:    [dynamic]types.Server, // List of servers the user is part of
+}
+
+// S2C_Login_Failure_Message is sent by the server on failed login.
+S2C_Login_Failure_Message :: struct {
+    using base: BaseMessage, // Should be S2C_LOGIN_FAILURE
+    error_message: string,
+}
+
+// C2S_Send_Message_Message is sent by the client to send a message to a channel.
+// The channel is implicit from the user's session.
+C2S_Send_Message_Message :: struct {
+    using base: BaseMessage, // Should be C2S_SEND_MESSAGE
+    content:    string,
+    image_path: string, // Optional: path to an image if attached
+}
+
+// S2C_New_Message_Message is broadcast by the server when a new message is posted.
+S2C_New_Message_Message :: struct {
+    using base: BaseMessage, // Should be S2C_NEW_MESSAGE
+    message:    types.Message,
+}
+
+// C2S_Join_Channel_Message is sent by the client to join a specific channel.
+C2S_Join_Channel_Message :: struct {
+    using base: BaseMessage, // Should be C2S_JOIN_CHANNEL
+    channel_name: string,
+}
+
+// S2C_User_Joined_Channel_Message is sent by the server to notify clients in a channel about a new user.
+S2C_User_Joined_Channel_Message :: struct {
+    using base: BaseMessage,     // Should be S2C_USER_JOINED_CHANNEL
+    channel_name: string,
+    user:         types.User,    // The user who joined
+}
+
+// C2S_Create_Channel_Message allows a client to request the creation of a new channel on a server.
+C2S_Create_Channel_Message :: struct {
+    using base: BaseMessage,
+    server_id:  u64,
+    name:       string,
+}
+
+// S2C_Channel_Created_Message is sent by the server to notify relevant clients that a new channel has been created.
+S2C_Channel_Created_Message :: struct {
+    using base: BaseMessage,
+    channel:    types.Channel,
+}
+
+// S2C_Error_Message is a generic error message sent by the server.
+S2C_Error_Message :: struct {
+    using base: BaseMessage,
+    error_message: string,
+    original_request_type: MessageType,
+}
+
+// Helper procedure to create a C2S_Login_Message
+create_c2s_login_message :: proc(username, password: string) -> C2S_Login_Message {
+    return C2S_Login_Message{
+        base = BaseMessage{type = .C2S_LOGIN},
+        username = username,
+        password = password,
+    };
+}
+
+// Helper procedure to create a C2S_Send_Message_Message
+create_c2s_send_message_message :: proc(content: string, image_path: string = "") -> C2S_Send_Message_Message {
+    return C2S_Send_Message_Message{
+        base = BaseMessage{type = .C2S_SEND_MESSAGE},
+        content = content,
+        image_path = image_path,
+    };
+}
+
+// Helper for C2S_Join_Channel_Message
+create_c2s_join_channel_message :: proc(channel_name: string) -> C2S_Join_Channel_Message {
+    return C2S_Join_Channel_Message{
+        base = BaseMessage{type = .C2S_JOIN_CHANNEL},
+        channel_name = channel_name,
+    };
+}

--- a/chat-app/src/shared/types.odin
+++ b/chat-app/src/shared/types.odin
@@ -34,7 +34,7 @@ Channel :: struct {
 Message :: struct {
     id:         u64,
     author_id:  u64,
-    channel_id: u64,
+    channel_name: string, // Name of the channel this message belongs to
     content:    string,
     image_path: string,  // For image attachments
     timestamp:  time.Time,


### PR DESCRIPTION
This commit introduces core chat features to both the server and client, enabling you to join a default channel, send messages, and see messages from others.

Server (`chat-app/src/server/main.odin`):
- In-Memory Channel Management:
    - Introduced `ChannelData` struct (name, users map, messages list).
    - Global `chat_channels` map (mutex-protected) to store channels.
    - Default "general" channel created on startup.
    - `ClientSession` now tracks `current_channel_name`.
- `C2S_JOIN_CHANNEL` Handling:
    - Allows clients to join channels (specifically "general" for now).
    - Updates `ChannelData.users` and `ClientSession.current_channel_name`.
    - Sends `S2C_User_Joined_Channel_Message` to the joining client.
    - Handles removal of users from previous channels if they switch.
    - Users are removed from their channel upon disconnection.
- `C2S_SEND_MESSAGE` Handling:
    - Validates user is in a channel.
    - Creates `types.Message` (with server-side timestamp and simple ID).
    - Stores message in the channel's `messages` list.
    - Broadcasts `S2C_New_Message_Message` to all users in the channel.
- Protocol Updates (`shared/protocol/protocol.odin`, `shared/types.odin`):
    - `C2S_Join_Channel_Message` and `S2C_User_Joined_Channel_Message` now use `channel_name: string`.
    - `C2S_Send_Message_Message` no longer includes `channel_id` (implicit from session).
    - `types.Message` now uses `channel_name: string`.

Client (`chat-app/src/client/main.odin`):
- Main Chat UI Structure:
    - Basic layout for channel list, message display, user list, and chat input.
    - `App` struct updated with `chat_message_buffer`, `current_chat_messages`, `current_channel_name`, and `chat_error_message`.
- Auto-Join Default Channel:
    - After successful login, client sends `C2S_JOIN_CHANNEL` for "general".
    - `app.current_channel_name` updated upon receiving `S2C_USER_JOINED_CHANNEL`.
- Displaying Messages:
    - Handles `S2C_NEW_MESSAGE` from server, appends to `current_chat_messages`.
    - Enforces a simple scrollback limit (e.g., 100 messages).
    - Renders messages in UI with basic author mapping ("You", "System", "User_<id>").
    - Messages are bottom-aligned in the display area.
- Sending Chat Messages:
    - Allows you to type in `chat_message_buffer` and send via "Send" button or Enter key.
    - Validates message content (non-empty).
    - Constructs and sends `C2S_Send_Message_Message` (JSON serialized with newline).
    - Clears input buffer on successful send.
    - Handles errors during send, displaying them in the chat UI or disconnecting.

This represents a significant step towards a functional chat application.